### PR TITLE
Bug 1480184: Proper support for empty .inc values

### DIFF
--- a/lib/silme/__init__.py
+++ b/lib/silme/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 9, 3, '', 0)
+VERSION = (0, 9, 4, '', 0)
 
 short_names = {
   'alpha': 'a',

--- a/lib/silme/format/inc/parser.py
+++ b/lib/silme/format/inc/parser.py
@@ -4,7 +4,7 @@ import re
 
 class IncParser():
     patterns = {}
-    patterns['entity'] = re.compile('^#define[ \t]*([^ \t]+)[ \t]*(.*)',re.M)
+    patterns['entity'] = re.compile(r'#define[ \t]+(?P<key>\w+)(?:[ \t](?P<val>[^\n]*))?', re.M)
     patterns['comment'] = re.compile('^(# [^\n]*\n?)+',re.M)
 #define firefox_about About Us
 
@@ -74,7 +74,7 @@ class IncParser():
                 object.append(text[pointer:st0])
             groups = match.groups()
             entity = Entity(groups[0])
-            entity.set_value(groups[1])
+            entity.set_value(groups[1] or '')
             entity.params['source'] = {'type':'inc',
                                         'string':match.group(0),
                                         'valpos':match.start(2)-st0}


### PR DESCRIPTION
Previously, empty translation values in .inc file format were only supported if the key was followed by a whitespace character:
https://github.com/mozilla/pontoon/blob/master/pontoon/sync/tests/formats/test_silme.py#L512

We're fixing that by using the parser regex from compare-locales:
https://github.com/Pike/compare-locales/blob/master/compare_locales/parser/defines.py#L41